### PR TITLE
fix: preserve judge command status

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -376,27 +376,21 @@ init_language() {
 }
 
 judge() {
+    local ret=$?
     local desc="$1"
     if [[ $# -gt 1 ]]; then
         "${@:2}"
-        local ret=$?
-        if [[ $ret -eq 0 ]]; then
-            log_echo "${OK} ${GreenBG} ${desc} $(gettext "完成") ${Font}"
-            sleep 0.5
-        else
-            log_echo "${Error} ${RedBG} ${desc} $(gettext "失败") ${Font}"
-            exit 1
-        fi
-        return $ret
-    else
-        if [[ 0 -eq $? ]]; then
-            log_echo "${OK} ${GreenBG} ${desc} $(gettext "完成") ${Font}"
-            sleep 0.5
-        else
-            log_echo "${Error} ${RedBG} ${desc} $(gettext "失败") ${Font}"
-            exit 1
-        fi
+        ret=$?
     fi
+
+    if [[ $ret -eq 0 ]]; then
+        log_echo "${OK} ${GreenBG} ${desc} $(gettext "完成") ${Font}"
+        sleep 0.5
+    else
+        log_echo "${Error} ${RedBG} ${desc} $(gettext "失败") ${Font}"
+        exit 1
+    fi
+    return $ret
 }
 
 check_version() {


### PR DESCRIPTION
  ## Summary / 摘要

  - Preserve the previous command exit status at the start of `judge()`.
  - 在 `judge()` 函数开始时先保存上一条命令的退出状态。
  - Fix false failure reports for `judge "desc"` calls after commands such as `curl ... && chmod ...`.
  - 修复 `curl ... && chmod ...` 等命令成功后，调用 `judge "描述"` 仍误报失败的问题。

  ## Validation / 验证

  - `bash -n install.sh fail2ban_manager.sh file_manager.sh auto_update.sh ssl_update.sh docker-entrypoint.sh fake-systemctl`
  - Tested the one-line installer from the fork branch successfully.
  - 已使用 fork 分支的一键安装命令测试通过。

  ## Context / 背景

  The one-line installer could report `[错误] 下载最新脚本 失败` even after `curl` successfully downloaded `install.sh`, because `judge()` clobbered `$?` before
  evaluating it.

  一键安装脚本中，`curl` 已成功下载 `install.sh` 后，仍可能输出 `[错误] 下载最新脚本 失败`。原因是 `judge()` 在判断前覆盖了 `$?`，导致无法读取上一条命令的真实退
  出状态。
