### PR TITLE
fix(ci): correct actions/cache immutable SHA in i18n workflows

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Restore translation cache
         id: cache-translations
-        uses: actions/cache/restore@1bd1e32a3b92759ce0baaad187b524d9d933182f # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: i18n/po/cache_*.json
           key: ${{ runner.os }}-translations-${{ hashFiles('i18n/po/*.po') }}
@@ -63,7 +63,7 @@ jobs:
           pip3 install polib deep-translator langdetect openai
 
       - name: Cache Python dependencies
-        uses: actions/cache@1bd1e32a3b92759ce0baaad187b524d9d933182f # v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-polib-deep-translator-langdetect-openai
@@ -158,7 +158,7 @@ jobs:
 
       - name: Save translation cache
         if: always() && steps.cache-translations.outputs.cache-hit != 'true' && hashFiles('i18n/po/cache_*.json') != ''
-        uses: actions/cache/save@1bd1e32a3b92759ce0baaad187b524d9d933182f # v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: i18n/po/cache_*.json
           key: ${{ runner.os }}-translations-${{ hashFiles('i18n/po/*.po') }}

--- a/.github/workflows/translate_readme.yml
+++ b/.github/workflows/translate_readme.yml
@@ -49,7 +49,7 @@ jobs:
           pip install deep-translator markdown beautifulsoup4
 
       - name: Cache Python dependencies
-        uses: actions/cache@1bd1e32a3b92759ce0baaad187b524d9d933182f # v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/translate_readme.py') }}
@@ -57,7 +57,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Restore translation cache
-        uses: actions/cache@1bd1e32a3b92759ce0baaad187b524d9d933182f # v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: translation_cache_readme.json
           key: ${{ runner.os }}-readme-translations-${{ hashFiles('README.md') }}


### PR DESCRIPTION
The P1-4 self-review pinned actions/cache to an invalid SHA (1bd1e32a3b9275...) that does not exist, so the i18n translation workflow failed at prepare-workflow-directory on every main commit. Fix: pin all actions/cache / restore / save to the real immutable v4.2.0 commit 1bd1e32a3bdc45362d1e726936510720a7c30a57. No production behavior change.