### PR TITLE
chore: bump shell_version to 3.1.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ OK="${Green}[OK]${Font}"
 Error="${RedW}[$(gettext "错误")]${Font}"
 Warning="${Yellow}[$(gettext "警告")]${Font}"
 
-shell_version="3.0.1"
+shell_version="3.1.0"
 shell_mode="$(gettext "未安装")"
 tls_mode="None"
 transport_mode="None"


### PR DESCRIPTION
将 install.sh 的 shell_version 从 3.0.1 提升到 3.1.0。