### PR TITLE
fix(ci): correct jq string concat in translation PR verification

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -205,7 +205,7 @@ jobs:
               --title "Update translations" \
               --body "Auto-generated translation update from the i18n workflow. This PR runs the normal CI gates before merge so production main is never produced without qualification."
           fi
-          VERIFIED=$(gh pr list --head i18n/auto-translations --json number,url --jq '.[0].number + " " + .[0].url')
+          VERIFIED=$(gh pr list --head i18n/auto-translations --json number,url --jq '.[0] | "\(.number) \(.url)"')
           if [ -z "$VERIFIED" ]; then
             echo "FAIL: translation changes staged on i18n/auto-translations but no PR exists" >&2
             exit 1


### PR DESCRIPTION
修复 i18n.yml 中 VERIFIED 验证的 jq 表达式：`.number` 是数字类型，不能与字符串 `+` 拼接，导致 Update Translations 工作流以 exit 1 失败。改用字符串插值 `.\[0\] | "\(.number) \(.url)"`。