### PR TITLE
ci(release): automate cross-repository publishing

### DIFF
--- a/.github/test/test_release_automation.py
+++ b/.github/test/test_release_automation.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "release_automation", ROOT / "scripts/release_automation.py"
+)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ReleaseAutomationTests(unittest.TestCase):
+    def test_package_sums_are_sorted_and_exclude_generated_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "z.txt").write_text("z")
+            (root / "a.txt").write_text("a")
+            (root / ".git").mkdir()
+            (root / ".git/config").write_text("secret")
+            (root / "__pycache__").mkdir()
+            (root / "__pycache__/x.pyc").write_bytes(b"cache")
+            MODULE.write_package_sums(root)
+            lines = (root / "PACKAGE_SHA256SUMS").read_text().splitlines()
+            self.assertEqual([line.split("  ", 1)[1] for line in lines], ["a.txt", "z.txt"])
+
+    def test_update_api_changes_online_fields_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            xray = root / "xray"
+            api = root / "api"
+            xray.mkdir()
+            api.mkdir()
+            (xray / "install.sh").write_text('shell_version="3.2.0"\n')
+            original = {
+                "update_date": "old",
+                "shell_online_version": "3.1.0",
+                "shell_tested_version": "2.8.3",
+                "shell_upgrade_details": "old details",
+                "xray_online_version": "26.3.27",
+            }
+            (api / "xray_shell_versions.json").write_text(json.dumps(original))
+            changed = MODULE.update_api(xray, api, "new details", "2026-08-14 02:00")
+            result = json.loads((api / "xray_shell_versions.json").read_text())
+            self.assertTrue(changed)
+            self.assertEqual(result["shell_online_version"], "3.2.0")
+            self.assertEqual(result["shell_tested_version"], "2.8.3")
+            self.assertEqual(result["xray_online_version"], "26.3.27")
+
+    def test_update_api_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            xray = root / "xray"
+            api = root / "api"
+            xray.mkdir()
+            api.mkdir()
+            (xray / "install.sh").write_text('shell_version="3.2.0"\n')
+            manifest = {"shell_online_version": "3.2.0"}
+            target = api / "xray_shell_versions.json"
+            target.write_text(json.dumps(manifest))
+            self.assertFalse(MODULE.update_api(xray, api, "unused", None))
+            self.assertEqual(json.loads(target.read_text()), manifest)
+
+    def test_update_api_refuses_downgrade(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            xray = root / "xray"
+            api = root / "api"
+            xray.mkdir()
+            api.mkdir()
+            (xray / "install.sh").write_text('shell_version="3.1.0"\n')
+            (api / "xray_shell_versions.json").write_text(
+                json.dumps({"shell_online_version": "3.2.0"})
+            )
+            with self.assertRaises(SystemExit):
+                MODULE.update_api(xray, api, "details", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/publish-shell-version.yml
+++ b/.github/workflows/publish-shell-version.yml
@@ -1,0 +1,96 @@
+name: Publish Shell Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      details:
+        description: Optional release summary; a deterministic default is used when empty
+        required: false
+        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - install.sh
+
+concurrency:
+  group: publish-shell-version
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+    steps:
+      - name: Require cross-repository token
+        run: |
+          set -euo pipefail
+          [[ -n "${GH_TOKEN:-}" ]] || {
+            echo "Configure RELEASE_AUTOMATION_TOKEN with Contents, Pull requests, and workflow-file write access to all three release repositories." >&2
+            exit 1
+          }
+
+      - name: Checkout released Xray main
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: main
+          path: xray
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout version API main
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          repository: hello-yunshu/Xray_bash_onekey_api
+          ref: main
+          path: api
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+          persist-credentials: false
+
+      - name: Prepare and validate version API update
+        id: update
+        env:
+          INPUT_DETAILS: ${{ inputs.details }}
+        run: |
+          set -euo pipefail
+          version=$(sed -n 's/^shell_version="\([0-9][0-9.]*\)"$/\1/p' xray/install.sh)
+          details=${INPUT_DETAILS:-}
+          [[ -n "${details}" ]] || details="release: publish shell ${version}"
+          python3 xray/scripts/release_automation.py update-api \
+            --xray xray --api api --details "${details}"
+          if git -C api diff --quiet; then
+            echo "changed=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "changed=true" >>"${GITHUB_OUTPUT}"
+          (cd api && bash validate-json.sh)
+          (cd api && bash .github/test/test_promote_validation.sh)
+          (cd api && bash .github/test/test_auto_update_preserves_tested.sh)
+          git -C api diff --check
+
+      - name: Publish and merge version API PR
+        if: steps.update.outputs.changed == 'true'
+        env:
+          API_REPO: hello-yunshu/Xray_bash_onekey_api
+        run: |
+          set -euo pipefail
+          version=$(sed -n 's/^shell_version="\([0-9][0-9.]*\)"$/\1/p' xray/install.sh)
+          branch="automation/shell-${version}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git -C api config user.name github-actions[bot]
+          git -C api config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git -C api switch -c "${branch}"
+          git -C api add xray_shell_versions.json
+          git -C api commit -m "chore(release): publish shell ${version}"
+          git -C api push "https://x-access-token:${GH_TOKEN}@github.com/${API_REPO}.git" "HEAD:${branch}"
+          pr_url=$(gh pr create --repo "${API_REPO}" --base main --head "${branch}" \
+            --title "chore(release): publish shell ${version}" \
+            --body "Automated after ${GITHUB_REPOSITORY}@${GITHUB_SHA} reached main. Updates only online shell metadata; tested-version fields remain manual.")
+          pr=${pr_url##*/}
+          xray/scripts/merge_checked_pr.sh "${API_REPO}" "${pr}"
+          curl -fsS "https://purge.jsdelivr.net/gh/hello-yunshu/Xray_bash_onekey_api@main/xray_shell_versions.json" >/dev/null || true

--- a/.github/workflows/sync-rill-canonical.yml
+++ b/.github/workflows/sync-rill-canonical.yml
@@ -1,0 +1,160 @@
+name: Sync Rill Canonical
+
+on:
+  workflow_run:
+    workflows:
+      - Test Install
+    types:
+      - completed
+
+concurrency:
+  group: sync-rill-canonical-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.head_branch != 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+      PYTHONDONTWRITEBYTECODE: "1"
+      SOURCE_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Checkout trusted automation from main
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: main
+          path: automation
+          persist-credentials: false
+
+      - name: Checkout Xray source branch
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          path: xray
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
+      - name: Checkout Rill canonical main
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          repository: hello-yunshu/rill-xray-agent
+          ref: main
+          path: rill
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect canonical script drift
+        id: drift
+        run: |
+          set -euo pipefail
+          changed=false
+          for name in \
+            rill_xray_agent_bootstrap.sh \
+            rill_xray_agent_install.sh \
+            rill_xray_agent_manager.sh \
+            rill_xray_agent_uninstall.sh \
+            rill_xray_agent_verify.sh; do
+            if ! cmp -s "xray/scripts/${name}" \
+              "rill/integrations/xray_bash_onekey/repository_files/scripts/${name}"; then
+              changed=true
+            fi
+          done
+          echo "changed=${changed}" >>"${GITHUB_OUTPUT}"
+
+      - name: Require cross-repository token
+        if: steps.drift.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          [[ -n "${GH_TOKEN:-}" ]] || {
+            echo "Configure RELEASE_AUTOMATION_TOKEN with Contents, Pull requests, and workflow-file write access to Xray_bash_onekey, rill-xray-agent, and Xray_bash_onekey_api." >&2
+            exit 1
+          }
+          [[ -n "${SOURCE_BRANCH}" && "${SOURCE_BRANCH}" != "main" ]]
+          [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ ]]
+
+      - name: Install canonical gate dependencies
+        if: steps.drift.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          python3 -m pip install jsonschema
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Build and verify canonical payload
+        if: steps.drift.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          python3 automation/scripts/release_automation.py sync-rill --xray xray --rill rill
+          (cd rill && python3 scripts/run_all_checks.py)
+          shellcheck --exclude=SC1091 rill/integrations/xray_bash_onekey/repository_files/scripts/*.sh
+          (cd rill && python3 scripts/verify_public_history_hygiene.py)
+          git -C rill diff --check
+
+      - name: Publish and merge canonical PR when needed
+        if: steps.drift.outputs.changed == 'true'
+        id: canonical
+        env:
+          RILL_REPO: hello-yunshu/rill-xray-agent
+        run: |
+          set -euo pipefail
+          git -C rill config user.name github-actions[bot]
+          git -C rill config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          canonical_sha=$(git -C rill rev-parse HEAD)
+          if ! git -C rill diff --quiet; then
+            branch="automation/xray-rill-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            git -C rill switch -c "${branch}"
+            git -C rill add --all
+            git -C rill commit -m "chore(xray): sync canonical integration"
+            git -C rill push "https://x-access-token:${GH_TOKEN}@github.com/${RILL_REPO}.git" "HEAD:${branch}"
+            pr_url=$(gh pr create --repo "${RILL_REPO}" --base main --head "${branch}" \
+              --title "chore(xray): sync canonical integration" \
+              --body "Automated deterministic synchronization from ${GITHUB_REPOSITORY}@${SOURCE_SHA}. Includes canonical source gates, manifest verification, package checksums, ShellCheck, and public-history hygiene.")
+            pr=${pr_url##*/}
+            automation/scripts/merge_checked_pr.sh "${RILL_REPO}" "${pr}" 2
+            canonical_sha=$(gh pr view "${pr}" --repo "${RILL_REPO}" \
+              --json mergeCommit --jq .mergeCommit.oid)
+          fi
+          [[ "${canonical_sha}" =~ ^[0-9a-f]{40}$ ]]
+          echo "sha=${canonical_sha}" >>"${GITHUB_OUTPUT}"
+
+      - name: Apply canonical output to Xray branch
+        if: steps.drift.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          python3 automation/scripts/release_automation.py apply-rill \
+            --xray xray --rill rill --commit "${{ steps.canonical.outputs.sha }}"
+          git -C xray diff --check
+
+      - name: Push canonical output back to the source branch
+        if: steps.drift.outputs.changed == 'true'
+        env:
+          XRAY_REPO: hello-yunshu/Xray_bash_onekey
+        run: |
+          set -euo pipefail
+          if git -C xray diff --quiet; then
+            echo "Xray branch already matches canonical payload."
+            exit 0
+          fi
+          git -C xray config user.name github-actions[bot]
+          git -C xray config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git -C xray add \
+            .github/workflows/rill-xray-agent.yml \
+            assets/rill-xray-agent-xray-bundle.tar.gz \
+            scripts/rill_xray_agent_bootstrap.sh \
+            scripts/rill_xray_agent_install.sh \
+            scripts/rill_xray_agent_manager.sh \
+            scripts/rill_xray_agent_uninstall.sh \
+            scripts/rill_xray_agent_verify.sh
+          git -C xray commit -m "chore(rill): apply canonical payload"
+          git -C xray push "https://x-access-token:${GH_TOKEN}@github.com/${XRAY_REPO}.git" \
+            "HEAD:${SOURCE_BRANCH}"

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -101,6 +101,10 @@ jobs:
           bash .github/test/test_nginx_health_production_defaults.sh
           # Candidate semantic self-check (P1-4)
           bash .github/test/test_candidate_self_check.sh
+          # Cross-repository release automation must remain deterministic and
+          # must never overwrite manually promoted tested-version metadata.
+          python3 .github/test/test_release_automation.py
+          bash -n scripts/merge_checked_pr.sh
 
       - name: Run user-safety regression tests
         run: |

--- a/docs/RELEASE_AUTOMATION.md
+++ b/docs/RELEASE_AUTOMATION.md
@@ -1,0 +1,23 @@
+# Cross-repository release automation
+
+The release chain is split across three repositories, but synchronization is automatic:
+
+1. A same-repository Xray PR passes `Test Install`.
+2. `Sync Rill Canonical` loads its automation code from protected `main`, compares the PR's five `rill_xray_agent_*.sh` integration files, rebuilds and verifies the canonical payload when needed, opens a Rill PR, waits for its checks, merges it, and commits the canonical bundle and SHA back to the same Xray branch.
+3. After the Xray PR reaches `main`, `Publish Shell Version` reads `shell_version` from `install.sh`, opens a version API PR, waits for its checks, merges it, and refreshes the CDN cache.
+
+## One-time credential
+
+Add an Actions secret named `RELEASE_AUTOMATION_TOKEN` to `Xray_bash_onekey`. Use a fine-grained token restricted to these repositories:
+
+- `hello-yunshu/Xray_bash_onekey`
+- `hello-yunshu/rill-xray-agent`
+- `hello-yunshu/Xray_bash_onekey_api`
+
+Grant repository permissions `Contents: Read and write`, `Pull requests: Read and write`, and permission to update workflow files. For a classic token, include the `workflow` scope. The workflows fail closed before checkout or mutation when the secret is absent.
+
+The token is used only for cross-repository branches and pull requests. Each generated PR is merged only after all of its checks complete successfully. A failed or timed-out check leaves the PR open and stops the chain.
+
+## Manual recovery
+
+Re-run the affected PR's `Test Install` workflow to retry canonical synchronization. `Publish Shell Version` also supports `workflow_dispatch` from `main`. All transforms are idempotent, so an already synchronized repository produces no commit.

--- a/scripts/merge_checked_pr.sh
+++ b/scripts/merge_checked_pr.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=${1:?repository is required}
+pr=${2:?pull request number is required}
+minimum_checks=${3:-1}
+attempts=${PR_CHECK_ATTEMPTS:-90}
+interval=${PR_CHECK_INTERVAL:-10}
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+    payload=$(gh pr view "${pr}" --repo "${repo}" \
+        --json state,mergeable,statusCheckRollup)
+    state=$(jq -r '.state' <<<"${payload}")
+    [[ "${state}" == "OPEN" ]] || {
+        [[ "${state}" == "MERGED" ]] && exit 0
+        echo "PR ${repo}#${pr} entered unexpected state ${state}" >&2
+        exit 1
+    }
+
+    count=$(jq '.statusCheckRollup | length' <<<"${payload}")
+    pending=$(jq '[.statusCheckRollup[] | select(.status != "COMPLETED")] | length' <<<"${payload}")
+    failed=$(jq '[.statusCheckRollup[] | select(
+        .status == "COMPLETED" and
+        (.conclusion != "SUCCESS" and .conclusion != "NEUTRAL" and .conclusion != "SKIPPED")
+    ] | length' <<<"${payload}")
+    mergeable=$(jq -r '.mergeable' <<<"${payload}")
+
+    if ((failed > 0)); then
+        gh pr checks "${pr}" --repo "${repo}" || true
+        echo "PR ${repo}#${pr} has a failed check" >&2
+        exit 1
+    fi
+    if ((count >= minimum_checks && pending == 0)) && [[ "${mergeable}" == "MERGEABLE" ]]; then
+        gh pr merge "${pr}" --repo "${repo}" --merge --delete-branch
+        [[ "$(gh pr view "${pr}" --repo "${repo}" --json state --jq .state)" == "MERGED" ]]
+        exit 0
+    fi
+    sleep "${interval}"
+done
+
+echo "timed out waiting for PR ${repo}#${pr}" >&2
+exit 1

--- a/scripts/release_automation.py
+++ b/scripts/release_automation.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Deterministic helpers for the cross-repository shell release chain."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+RILL_SCRIPTS = (
+    "rill_xray_agent_bootstrap.sh",
+    "rill_xray_agent_install.sh",
+    "rill_xray_agent_manager.sh",
+    "rill_xray_agent_uninstall.sh",
+    "rill_xray_agent_verify.sh",
+)
+BUNDLE = "rill-xray-agent-xray-bundle.tar.gz"
+VERSION_RE = re.compile(r'^shell_version="([0-9]+\.[0-9]+\.[0-9]+)"$', re.MULTILINE)
+PIN_RE = re.compile(r"^  RILL_CANONICAL_COMMIT: [0-9a-f]{40}$", re.MULTILINE)
+
+
+def run(*argv: str, cwd: Path) -> None:
+    subprocess.run(argv, cwd=cwd, check=True)
+
+
+def copy_file(source: Path, target: Path) -> None:
+    if not source.is_file():
+        raise SystemExit(f"missing source file: {source}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+
+
+def package_files(root: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.name == "PACKAGE_SHA256SUMS":
+            continue
+        rel = path.relative_to(root)
+        if rel.parts and rel.parts[0] == ".git":
+            continue
+        if any(part in {"__pycache__", ".pytest_cache", "target"} for part in rel.parts):
+            continue
+        if path.name.endswith(".pyc"):
+            continue
+        result[rel.as_posix()] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return result
+
+
+def write_package_sums(root: Path) -> None:
+    sums = package_files(root)
+    body = "".join(f"{digest}  {name}\n" for name, digest in sorted(sums.items()))
+    (root / "PACKAGE_SHA256SUMS").write_text(body)
+
+
+def sync_rill(xray: Path, rill: Path) -> None:
+    target_scripts = rill / "integrations/xray_bash_onekey/repository_files/scripts"
+    for name in RILL_SCRIPTS:
+        copy_file(xray / "scripts" / name, target_scripts / name)
+
+    run(sys.executable, "scripts/sync_xray_payload.py", cwd=rill)
+    run(sys.executable, "scripts/build_canonical_manifest.py", cwd=rill)
+    write_package_sums(rill)
+    run(sys.executable, "scripts/build_canonical_manifest.py", "--check", cwd=rill)
+    run(sys.executable, "scripts/verify_xray_integration.py", cwd=rill)
+    run(sys.executable, "scripts/verify_package_sums.py", cwd=rill)
+
+
+def apply_rill(xray: Path, rill: Path, commit: str) -> None:
+    if not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise SystemExit("canonical commit must be a full 40-character SHA")
+    integration = rill / "integrations/xray_bash_onekey"
+    source_scripts = integration / "repository_files/scripts"
+    for name in RILL_SCRIPTS:
+        copy_file(source_scripts / name, xray / "scripts" / name)
+    copy_file(integration / "assets" / BUNDLE, xray / "assets" / BUNDLE)
+
+    workflow = xray / ".github/workflows/rill-xray-agent.yml"
+    text = workflow.read_text()
+    updated, count = PIN_RE.subn(f"  RILL_CANONICAL_COMMIT: {commit}", text, count=1)
+    if count != 1:
+        raise SystemExit(f"RILL_CANONICAL_COMMIT anchor missing or ambiguous: {workflow}")
+    workflow.write_text(updated)
+
+    run(
+        sys.executable,
+        str(integration / "tools/verify_xray_payload.py"),
+        str(xray),
+        str(integration / "CANONICAL_MANIFEST.json"),
+        cwd=xray,
+    )
+
+
+def version_tuple(value: str) -> tuple[int, int, int]:
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", value):
+        raise SystemExit(f"invalid shell version: {value}")
+    return tuple(int(part) for part in value.split("."))  # type: ignore[return-value]
+
+
+def shell_version(xray: Path) -> str:
+    matches = VERSION_RE.findall((xray / "install.sh").read_text())
+    if len(matches) != 1:
+        raise SystemExit("install.sh must contain exactly one shell_version anchor")
+    return matches[0]
+
+
+def update_api(xray: Path, api: Path, details: str, update_date: str | None) -> bool:
+    version = shell_version(xray)
+    manifest_path = api / "xray_shell_versions.json"
+    manifest = json.loads(manifest_path.read_text())
+    current = manifest.get("shell_online_version")
+    if not isinstance(current, str):
+        raise SystemExit("shell_online_version is missing from the API manifest")
+    if version_tuple(version) < version_tuple(current):
+        raise SystemExit(f"refusing shell version downgrade: {current} -> {version}")
+    if version == current:
+        print(f"version API already publishes shell {version}")
+        return False
+
+    if not details.strip():
+        raise SystemExit("release details must not be empty")
+    if update_date is None:
+        update_date = dt.datetime.now(dt.timezone(dt.timedelta(hours=8))).strftime("%Y-%m-%d %H:%M")
+    manifest["update_date"] = update_date
+    manifest["shell_online_version"] = version
+    manifest["shell_upgrade_details"] = details.strip()
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n")
+    print(f"prepared version API update: {current} -> {version}")
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sync = sub.add_parser("sync-rill")
+    sync.add_argument("--xray", type=Path, required=True)
+    sync.add_argument("--rill", type=Path, required=True)
+
+    apply = sub.add_parser("apply-rill")
+    apply.add_argument("--xray", type=Path, required=True)
+    apply.add_argument("--rill", type=Path, required=True)
+    apply.add_argument("--commit", required=True)
+
+    api = sub.add_parser("update-api")
+    api.add_argument("--xray", type=Path, required=True)
+    api.add_argument("--api", type=Path, required=True)
+    api.add_argument("--details", required=True)
+    api.add_argument("--date")
+
+    args = parser.parse_args()
+    if args.command == "sync-rill":
+        sync_rill(args.xray.resolve(), args.rill.resolve())
+    elif args.command == "apply-rill":
+        apply_rill(args.xray.resolve(), args.rill.resolve(), args.commit)
+    else:
+        changed = update_api(args.xray.resolve(), args.api.resolve(), args.details, args.date)
+        print(f"changed={'true' if changed else 'false'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- automatically synchronize changed Rill integration scripts into the canonical repository after trusted Test Install success
- wait for canonical checks, merge its PR, and write the deterministic bundle and canonical SHA back to the Xray branch
- automatically publish shell version metadata through a checked API PR after Xray reaches main
- keep tested-version metadata manual and fail closed on downgrades, missing credentials, failed checks, or timeouts

## Security
- workflow_run executes automation code from protected main; PR content is treated only as synchronization input
- one fine-grained RELEASE_AUTOMATION_TOKEN is required for cross-repository writes

## Verification
- release automation unit tests: 4/4
- canonical sync and apply idempotence
- API publish idempotence and downgrade rejection
- actionlint, shellcheck, bash syntax, msgfmt, git diff check
- version loading regression: 6/6