### PR TITLE
fix(ci): close jq select parenthesis in merge_checked_pr.sh

### DIFF
--- a/scripts/merge_checked_pr.sh
+++ b/scripts/merge_checked_pr.sh
@@ -22,7 +22,7 @@ for ((attempt = 1; attempt <= attempts; attempt++)); do
     failed=$(jq '[.statusCheckRollup[] | select(
         .status == "COMPLETED" and
         (.conclusion != "SUCCESS" and .conclusion != "NEUTRAL" and .conclusion != "SKIPPED")
-    ] | length' <<<"${payload}")
+    )] | length' <<<"${payload}")
     mergeable=$(jq -r '.mergeable' <<<"${payload}")
 
     if ((failed > 0)); then


### PR DESCRIPTION
The 'failed' status-check query was missing the closing parenthesis for select(), causing jq to abort with a syntax error on every iteration. This silently breaks the auto-merge wait loop used by publish-shell-version and sync-rill-canonical (and the new translation auto-merge step).